### PR TITLE
Fix: launchapp not iterating through all apps in app_list

### DIFF
--- a/hisense.py
+++ b/hisense.py
@@ -596,7 +596,7 @@ class TVAuthenticator:
                     app_id = app["appId"]
                     app_url = app["url"]
                     app_name = app["name"]
-                break
+                    break
 
             if app_id is None or app_url is None:
                 print("Failed to find app in app list.")


### PR DESCRIPTION
This pull request addresses an issue where, if an app name other than the first one in the `app_list` was provided, the message `Failed to find app in app list.` would appear.

The bug was caused by a misplaced `break` statement that was outside the loop, preventing the function from iterating through the entire list. I have moved the `break` inside the loop where `app_name` is compared to the names in the list, allowing the function to properly check all apps in the list.